### PR TITLE
Fix QtDCMConfig.cmake.in

### DIFF
--- a/CMake/QtDCMConfig.cmake.in
+++ b/CMake/QtDCMConfig.cmake.in
@@ -5,18 +5,16 @@
 set(QTDCM_SOURCE_DIR "@QtDcm_SOURCE_DIR@/Code")
 
 #path to cmake files of Vistal
-set(QTDCM_CMAKE_DIR "@QtDcm_CMAKE_DIR@")
+set(QTDCM_CMAKE_DIR "@QtDcm_SOURCE_DIR@/CMake")
 
 #path to binary dir of QTDCM
-set(QTDCM_BINARY_DIR "@QtDcm_BINARY_DIR@")
+set(QTDCM_BINARY_DIR "@QtDcm_BINARY_DIR@/lib")
 
 # all include dirs pour QTDCM
-set(QTDCM_INCLUDE_DIRS  "@QtDcm_INCLUDE_DIRS@")
+set(QTDCM_INCLUDE_DIRS  "@QtDcm_SOURCE_DIR@/Code")
 
 # all library dirs pour QTDCM
-set(QTDCM_LIBRARY_DIRS  "@QtDcm_LIBRARY_DIRS@")
-
-set(QTDCM_CMAKE_MODULE_PATH "@QtDcm_CMAKE_MODULE_PATH@")
+set(QTDCM_LIBRARY_DIRS  "@QtDcm_BINARY_DIR@/lib")
 
 # The Vistal version number
 set(QTDCM_VERSION_MAJOR "@QtDcm_VERSION_MAJOR@")


### PR DESCRIPTION
The `QtDcm_LIBRARY_DIRS` is empty, it is not defined somwhere else in the project. the `set(QTDCM_SOURCE_DIR "@QtDcm_SOURCE_DIR@/Code")` works because CMake automatically internally define the `${${PROJECT_NAME}_BINARY_DIR}`  and `${${PROJECT_NAME}_SOURCE_DIR}`