### PR TITLE
Add option to use FindDCMTK modules or not.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,14 @@ if(BUILD_DOCUMENTATION)
   add_subdirectory(Documentation/Doxygen)
 endif()
 
+option(DCMTK_FIND_PACKAGE_USE_CONFIG_ONLY 
+  "Do not use any FindDCMTK.cmake module found in the CMAKE_MODULE_PATH to find DCMTK." 
+  OFF)
+
+if(DCMTK_FIND_PACKAGE_USE_CONFIG_ONLY)
+  set(DCMTK_FIND_PACKAGE_STATEGY NO_MODULE)
+endif()
+
 set (${PROJECT_NAME}_CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMake)
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${${PROJECT_NAME}_CMAKE_MODULE_PATH}")
 

--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -2,10 +2,10 @@ include (${${PROJECT_NAME}_SOURCE_DIR}/CMake/QtDCMSettings.cmake)
 
 find_package( Qt5 REQUIRED COMPONENTS Core Widgets Network)
 
-find_package(DCMTK REQUIRED)
+find_package(DCMTK REQUIRED ${DCMTK_FIND_PACKAGE_STATEGY})
 include_directories(${DCMTK_INCLUDE_DIRS})
 
-if(APPLE)
+if(APPLE AND NOT DCMTK_FIND_PACKAGE_USE_CONFIG_ONLY)
   include(FixDCMTKMacInstall)
   FixDCMTKMacInstall()
 endif()
@@ -43,7 +43,7 @@ set(${PROJECT_NAME}_UIS
   qtdcmpreferenceswidget.ui
 )
 
-set(${PROJECT_NAME}_MOC_HDRS   
+set(${PROJECT_NAME}_MOC_HDRS
   QtDcm.h
   QtDcmImportWidget.h
   QtDcmPreviewWidget.h
@@ -91,11 +91,11 @@ qt5_wrap_ui( ${PROJECT_NAME}_UI_HDRS ${${PROJECT_NAME}_UIS})
 qt5_wrap_cpp( ${PROJECT_NAME}_MOC_SRCS ${${PROJECT_NAME}_MOC_HDRS})
 
 include_directories(
-  ${CMAKE_BINARY_DIR} 
-  ${${PROJECT_NAME}_SOURCE_DIR}/Code 
-  ${${PROJECT_NAME}_BINARY_DIR}/Code 
-  ${ITK_INCLUDE_DIRS} 
-  ${VTK_INCLUDE_DIRS} 
+  ${CMAKE_BINARY_DIR}
+  ${${PROJECT_NAME}_SOURCE_DIR}/Code
+  ${${PROJECT_NAME}_BINARY_DIR}/Code
+  ${ITK_INCLUDE_DIRS}
+  ${VTK_INCLUDE_DIRS}
   ${DCMTK_INCLUDE_DIR}
 )
 
@@ -127,7 +127,7 @@ target_link_libraries(qtdcm
   ${${PROJECT_NAME}_LIBRARIES}
 )
 
-if(APPLE)
+if(APPLE AND NOT DCMTK_FIND_PACKAGE_USE_CONFIG_ONLY)
   include(FixDCMTKMacLink)
   FixDCMTKMacLibLink(qtdcm)
 endif()


### PR DESCRIPTION
We wish to be able to not use the FindDCMTK modules to find DCMTK when we're building QtDCM from the superproject. 

The FindDCMTK modules are always use in prior if they are found in the CMAKE_MODULE_PATH. to skip them, one have to add the CONFIG or NO_MODULE flag in the find_package() command. 
See https://cmake.org/cmake/help/v3.3/command/find_package.

The reason why we don't want to use the FindDCMTK ship with cmake is that it automatically find  the system installed version if there is any.

The one provided by QtDCM fix this issue, but depending on the platform used, it may require that DCMTK has been installed after the build step. (Otherwise It fails to retrieve the lib from the build, their location is not always the same depending on the platform AND the compilation tool-chain used, for example visual studio create Release, Debug, etc folder, while if you use the MSVC compiler with ninja they are not created.)

Use the DCMTKConfig.cmake ensure us to always find all what we need and allow us to skip the install step, and then get rid of the fix needed on APPLE platform to find the link and include directories when DCMTK has been installed (FixDCMTKMacInstall and FixDCMTKMacLink) .